### PR TITLE
fixed problems with feature term

### DIFF
--- a/convert-ga4gh/src/main/java/org/bdgenomics/convert/ga4gh/BdgenomicsFeatureToGa4ghFeature.java
+++ b/convert-ga4gh/src/main/java/org/bdgenomics/convert/ga4gh/BdgenomicsFeatureToGa4ghFeature.java
@@ -62,12 +62,15 @@ final class BdgenomicsFeatureToGa4ghFeature extends AbstractConverter<org.bdgeno
             return null;
         }
 
-        return ga4gh.SequenceAnnotations.Feature.newBuilder()
+        ga4gh.SequenceAnnotations.Feature.Builder builder =   ga4gh.SequenceAnnotations.Feature.newBuilder()
             .setStart(feature.getStart())
             .setEnd(feature.getEnd())
             .setStrand(strandConverter.convert(feature.getStrand(), stringency, logger))
-            .setReferenceName(feature.getContigName())
-            .setFeatureType(featureTypeConverter.convert(feature.getFeatureType(), stringency, logger))
-            .build();
+            .setReferenceName(feature.getContigName());
+
+        if(feature.getFeatureType() != null) {
+            builder.setFeatureType( ga4gh.Common.OntologyTerm.newBuilder().setTermId(feature.getFeatureType()) );
+        }
+        return builder.build();
     }
 }


### PR DESCRIPTION
turns out that for bdg feature:
`feature.getFeatureType()`
returns just a String not an ontologyTerm.

We can also actually eliminate 
`private final Converter<String, ga4gh.Common.OntologyTerm> featureTypeConverter;`
completely from class `BdgenomicsFeatureToGa4ghFeature`
which I will do before asking for merge here, unless other feedback.

The previous  code causes problems with null pointer if featureType  is null, and the ontology term converter as it is right now doesn't actually set the term anyhow.

This PR is needed for mango work.
