### PR TITLE
Add null guards in ga4gh and fix feature ga4gh converter

### DIFF
--- a/convert-ga4gh/src/main/java/org/bdgenomics/convert/ga4gh/BdgenomicsFeatureToGa4ghFeature.java
+++ b/convert-ga4gh/src/main/java/org/bdgenomics/convert/ga4gh/BdgenomicsFeatureToGa4ghFeature.java
@@ -62,12 +62,22 @@ final class BdgenomicsFeatureToGa4ghFeature extends AbstractConverter<org.bdgeno
             return null;
         }
 
-        return ga4gh.SequenceAnnotations.Feature.newBuilder()
-            .setStart(feature.getStart())
-            .setEnd(feature.getEnd())
-            .setStrand(strandConverter.convert(feature.getStrand(), stringency, logger))
-            .setReferenceName(feature.getContigName())
-            .setFeatureType(featureTypeConverter.convert(feature.getFeatureType(), stringency, logger))
-            .build();
+        ga4gh.SequenceAnnotations.Feature.Builder builder =   ga4gh.SequenceAnnotations.Feature.newBuilder();
+        if(feature.getStart() != null) {
+           builder.setStart(feature.getStart());
+        }
+        if(feature.getEnd() != null) {
+           builder.setEnd(feature.getEnd());
+        }
+        if(feature.getStrand() != null) {
+           builder.setStrand(strandConverter.convert(feature.getStrand(), stringency, logger));
+        }
+        if(feature.getContigName() != null) {
+           builder.setReferenceName(feature.getContigName());
+        }
+        if(feature.getFeatureType() != null) {
+            builder.setFeatureType( ga4gh.Common.OntologyTerm.newBuilder().setTermId(feature.getFeatureType()) );
+        }
+        return builder.build();
     }
 }

--- a/convert-ga4gh/src/main/java/org/bdgenomics/convert/ga4gh/BdgenomicsGenotypeToGa4ghCall.java
+++ b/convert-ga4gh/src/main/java/org/bdgenomics/convert/ga4gh/BdgenomicsGenotypeToGa4ghCall.java
@@ -73,12 +73,14 @@ public class BdgenomicsGenotypeToGa4ghCall extends AbstractConverter<org.bdgenom
 
         java.util.List<Double> gl = genotype.getGenotypeLikelihoods();
 
-        ga4gh.Variants.Call.Builder builder = ga4gh.Variants.Call.newBuilder()
-                .setCallSetName(genotype.getSampleId())
-                .setCallSetId("NA")
-                .setGenotype(calls);
+        ga4gh.Variants.Call.Builder builder = ga4gh.Variants.Call.newBuilder();
+        if(genotype.getSampleId() != null) {
+            builder.setCallSetName(genotype.getSampleId());
+        }
 
-        if (genotype.getPhased()) {
+        builder.setGenotype(calls);
+
+        if (genotype.getPhased() && genotype.getPhaseSetId() != null) {
             builder = builder.setPhaseset(genotype.getPhaseSetId().toString());
 
         }

--- a/convert-ga4gh/src/main/java/org/bdgenomics/convert/ga4gh/BdgenomicsVariantToGa4ghVariant.java
+++ b/convert-ga4gh/src/main/java/org/bdgenomics/convert/ga4gh/BdgenomicsVariantToGa4ghVariant.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,6 +18,7 @@
 package org.bdgenomics.convert.ga4gh;
 
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
 import java.util.Arrays;
 import javax.annotation.concurrent.Immutable;
 
@@ -39,20 +40,40 @@ public class BdgenomicsVariantToGa4ghVariant extends AbstractConverter<org.bdgen
                                           final ConversionStringency stringency,
                                           final Logger logger) throws ConversionException {
         if (variant == null) {
-                warnOrThrow(variant, "must not be null", null, stringency, logger);
-                return null;
-            }
+            warnOrThrow(variant, "must not be null", null, stringency, logger);
+            return null;
+        }
 
-        return ga4gh.Variants.Variant.newBuilder()
-                .addAllNames(variant.getNames())
-                .setReferenceName(variant.getContigName())
-                .setStart(variant.getStart())
-                .setEnd(variant.getEnd())
-                .setReferenceBases(variant.getReferenceAllele())
-                .addAllAlternateBases(Arrays.asList(variant.getAlternateAllele() ))
-                .addAllFiltersFailed(variant.getFiltersFailed())
-                .setFiltersPassed(variant.getFiltersPassed())
-                .setFiltersApplied(variant.getFiltersApplied())
-                .build();
+        ga4gh.Variants.Variant.Builder builder = ga4gh.Variants.Variant.newBuilder();
+
+        if (variant.getNames() != null && !variant.getNames().isEmpty()) {
+            builder.addAllNames(variant.getNames());
+        }
+        if (variant.getContigName() != null) {
+            builder.setReferenceName(variant.getContigName());
+        }
+        if (variant.getStart() != null) {
+            builder.setStart(variant.getStart());
+        }
+        if (variant.getEnd() != null) {
+            builder.setEnd(variant.getEnd());
+        }
+        if (variant.getReferenceAllele() != null) {
+            builder.setReferenceBases(variant.getReferenceAllele());
+        }
+        if (variant.getAlternateAllele() != null) {
+            builder.addAllAlternateBases(Arrays.asList(variant.getAlternateAllele()));
+        }
+        if (variant.getFiltersFailed() != null && !variant.getFiltersFailed().isEmpty()) {
+            builder.addAllFiltersFailed(variant.getFiltersFailed());
+        }
+        if (variant.getFiltersPassed() != null) {
+            builder.setFiltersPassed(variant.getFiltersPassed());
+        }
+        if (variant.getFiltersApplied() != null) {
+            builder.setFiltersPassed(variant.getFiltersApplied());
+        }
+
+        return builder.build();
     }
 }


### PR DESCRIPTION
if possible I'd like to merge this but avoid having @heuermh  cut a new release until
we have finished the current mango work that depends on this - in case we find more bugs that need to be fixed here in `convert`.  

However, I'm not clear if building `convert` locally from this PR will be OK for now @akmorrow13 and still be OK to commit to mango master snapshot with this not published dependency?
