### PR TITLE
[CONVERT-44] Update bdg-formats dependency to version 0.11.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <java.version>1.8</java.version>
-    <bdg-formats.version>0.11.1</bdg-formats.version>
+    <bdg-formats.version>0.11.3</bdg-formats.version>
     <commons-lang3.version>3.6</commons-lang3.version>
     <ga4gh.version>0.6.0a10</ga4gh.version>
     <guice.version>4.1.0</guice.version>


### PR DESCRIPTION
Fixes #44 

GA4GH variant doesn't have a quality field, so there aren't any code changes here.