### PR TITLE
Adding GA4GH program, read group converters.

### DIFF
--- a/convert-ga4gh/src/main/java/org/bdgenomics/convert/ga4gh/Ga4ghModule.java
+++ b/convert-ga4gh/src/main/java/org/bdgenomics/convert/ga4gh/Ga4ghModule.java
@@ -21,9 +21,12 @@ import java.util.List;
 
 import javax.annotation.concurrent.Immutable;
 
+import ga4gh.Common.Program;
+
 import ga4gh.Reads.CigarUnit;
 import ga4gh.Reads.CigarUnit.Operation;
 import ga4gh.Reads.ReadAlignment;
+import ga4gh.Reads.ReadGroup;
 
 import htsjdk.samtools.Cigar;
 import htsjdk.samtools.CigarOperator;
@@ -36,6 +39,8 @@ import org.bdgenomics.convert.Converter;
 
 import org.bdgenomics.formats.avro.AlignmentRecord;
 import org.bdgenomics.formats.avro.GenotypeAllele;
+import org.bdgenomics.formats.avro.ProcessingStep;
+import org.bdgenomics.formats.avro.RecordGroup;
 
 /**
  * Guice module for the org.bdgenomics.convert.ga4gh package.
@@ -105,5 +110,25 @@ public final class Ga4ghModule extends AbstractModule {
     @Provides @Singleton
     Converter<org.bdgenomics.formats.avro.Feature, ga4gh.SequenceAnnotations.Feature> createBdgenomicsFeatureToGa4ghFeature(final Converter<String, ga4gh.Common.OntologyTerm> featureTypeConverter, final Converter<org.bdgenomics.formats.avro.Strand, ga4gh.Common.Strand> strandConverter) {
         return new BdgenomicsFeatureToGa4ghFeature(featureTypeConverter, strandConverter);
+    }
+
+    @Provides @Singleton
+    Converter<Program, ProcessingStep> createProgramToProcessingStep() {
+        return new ProgramToProcessingStep();
+    }
+
+    @Provides @Singleton
+    Converter<ProcessingStep, Program> createProcessingStepToProgram() {
+        return new ProcessingStepToProgram();
+    }
+
+    @Provides @Singleton
+    Converter<ReadGroup, RecordGroup> createReadGroupToRecordGroup(final Converter<Program, ProcessingStep> programConverter) {
+        return new ReadGroupToRecordGroup(programConverter);
+    }
+
+    @Provides @Singleton
+    Converter<RecordGroup, ReadGroup> createRecordGroupToReadGroup(final Converter<ProcessingStep, Program> processingStepConverter) {
+        return new RecordGroupToReadGroup(processingStepConverter);
     }
 }

--- a/convert-ga4gh/src/main/java/org/bdgenomics/convert/ga4gh/ProcessingStepToProgram.java
+++ b/convert-ga4gh/src/main/java/org/bdgenomics/convert/ga4gh/ProcessingStepToProgram.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.convert.ga4gh;
+
+import javax.annotation.concurrent.Immutable;
+
+import ga4gh.Common.Program;
+
+import org.bdgenomics.convert.AbstractConverter;
+import org.bdgenomics.convert.ConversionException;
+import org.bdgenomics.convert.ConversionStringency;
+
+import org.bdgenomics.formats.avro.ProcessingStep;
+
+import org.slf4j.Logger;
+
+/**
+ * Convert bdg-formats ProcessingStep to GA4GH Program.
+ */
+@Immutable
+final class ProcessingStepToProgram extends AbstractConverter<ProcessingStep, Program> {
+
+    /**
+     * Convert bdg-formats ProcessingStep to GA4GH Program.
+     */
+    ProcessingStepToProgram() {
+        super(ProcessingStep.class, Program.class);
+    }
+
+
+    @Override
+    public Program convert(final ProcessingStep processingStep,
+                           final ConversionStringency stringency,
+                           final Logger logger) throws ConversionException {
+
+        if (processingStep == null) {
+            warnOrThrow(processingStep, "must not be null", null, stringency, logger);
+            return null;
+        }
+
+        return Program.newBuilder()
+            .setId(processingStep.getId())
+            .setName(processingStep.getProgramName())
+            .setCommandLine(processingStep.getCommandLine())
+            .setPrevProgramId(processingStep.getPreviousId())
+            .setVersion(processingStep.getVersion())
+            .build();
+    }
+}

--- a/convert-ga4gh/src/main/java/org/bdgenomics/convert/ga4gh/ProgramToProcessingStep.java
+++ b/convert-ga4gh/src/main/java/org/bdgenomics/convert/ga4gh/ProgramToProcessingStep.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.convert.ga4gh;
+
+import javax.annotation.concurrent.Immutable;
+
+import ga4gh.Common.Program;
+
+import org.bdgenomics.convert.AbstractConverter;
+import org.bdgenomics.convert.ConversionException;
+import org.bdgenomics.convert.ConversionStringency;
+
+import org.bdgenomics.formats.avro.ProcessingStep;
+
+import org.slf4j.Logger;
+
+/**
+ * Convert GA4GH Program to bdg-formats ProcessingStep.
+ */
+@Immutable
+final class ProgramToProcessingStep extends AbstractConverter<Program, ProcessingStep> {
+
+    /**
+     * Convert GA4GH Program to bdg-formats ProcessingStep.
+     */
+    ProgramToProcessingStep() {
+        super(Program.class, ProcessingStep.class);
+    }
+
+
+    @Override
+    public ProcessingStep convert(final Program program,
+                                  final ConversionStringency stringency,
+                                  final Logger logger) throws ConversionException {
+
+        if (program == null) {
+            warnOrThrow(program, "must not be null", null, stringency, logger);
+            return null;
+        }
+
+        return ProcessingStep.newBuilder()
+            .setId(program.getId())
+            .setProgramName(program.getName())
+            .setCommandLine(program.getCommandLine())
+            .setPreviousId(program.getPrevProgramId())
+            .setVersion(program.getVersion())
+            .build();
+    }
+}

--- a/convert-ga4gh/src/main/java/org/bdgenomics/convert/ga4gh/ReadGroupToRecordGroup.java
+++ b/convert-ga4gh/src/main/java/org/bdgenomics/convert/ga4gh/ReadGroupToRecordGroup.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.convert.ga4gh;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.concurrent.Immutable;
+
+import ga4gh.Common.Program;
+
+import ga4gh.Reads.ReadGroup;
+
+import org.bdgenomics.convert.AbstractConverter;
+import org.bdgenomics.convert.ConversionException;
+import org.bdgenomics.convert.ConversionStringency;
+import org.bdgenomics.convert.Converter;
+
+import org.bdgenomics.formats.avro.ProcessingStep;
+import org.bdgenomics.formats.avro.RecordGroup;
+
+import org.slf4j.Logger;
+
+/**
+ * Convert GA4GH ReadGroup to bdg-formats RecordGroup.
+ */
+@Immutable
+final class ReadGroupToRecordGroup extends AbstractConverter<ReadGroup, RecordGroup> {
+    /** Convert GA4GH Program to bdg-formats ProcessingStep. */
+    private final Converter<Program, ProcessingStep> programConverter;
+
+    /**
+     * Convert GA4GH ReadGroup to bdg-formats RecordGroup.
+     *
+     * @param programConverter GA4GH Program to bdg-formats ProcessingGroup converter,
+     *    must not be null
+     */
+    ReadGroupToRecordGroup(final Converter<Program, ProcessingStep> programConverter) {
+        super(ReadGroup.class, RecordGroup.class);
+        checkNotNull(programConverter);
+        this.programConverter = programConverter;
+    }
+
+
+    @Override
+    public RecordGroup convert(final ReadGroup readGroup,
+                               final ConversionStringency stringency,
+                               final Logger logger) throws ConversionException {
+
+        if (readGroup == null) {
+            warnOrThrow(readGroup, "must not be null", null, stringency, logger);
+            return null;
+        }
+
+        RecordGroup.Builder builder = RecordGroup.newBuilder()
+            // note ga4gh can have both id and name set, bdg-formats only name
+            .setName(readGroup.getName())
+            .setSample(readGroup.getSampleName())
+            .setDescription(readGroup.getDescription())
+            .setPredictedMedianInsertSize(readGroup.getPredictedInsertSize());
+
+        List<Program> programs = readGroup.getProgramsList();
+        if (!programs.isEmpty()) {
+            List<ProcessingStep> processingSteps = new ArrayList<ProcessingStep>(programs.size());
+            for (Program program : programs) {
+                processingSteps.add(programConverter.convert(program, stringency, logger));
+            }
+            builder.setProcessingSteps(processingSteps);
+        }
+        return builder.build();
+    }
+}

--- a/convert-ga4gh/src/main/java/org/bdgenomics/convert/ga4gh/RecordGroupToReadGroup.java
+++ b/convert-ga4gh/src/main/java/org/bdgenomics/convert/ga4gh/RecordGroupToReadGroup.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.convert.ga4gh;
+
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
+import javax.annotation.concurrent.Immutable;
+
+import ga4gh.Common.Program;
+
+import ga4gh.Reads.ReadGroup;
+
+import org.bdgenomics.convert.AbstractConverter;
+import org.bdgenomics.convert.ConversionException;
+import org.bdgenomics.convert.ConversionStringency;
+import org.bdgenomics.convert.Converter;
+
+import org.bdgenomics.formats.avro.ProcessingStep;
+import org.bdgenomics.formats.avro.RecordGroup;
+
+import org.slf4j.Logger;
+
+/**
+ * Convert bdg-formats RecordGroup to GA4GH ReadGroup.
+ */
+@Immutable
+final class RecordGroupToReadGroup extends AbstractConverter<RecordGroup, ReadGroup> {
+    /** Convert bdg-formats ProcessingStep to GA4GH Program. */
+    private final Converter<ProcessingStep, Program> processingStepConverter;
+
+    /**
+     * Convert bdg-formats RecordGroup to GA4GH ReadGroup.
+     *
+     * @param processingStepConverter bdg-formats ProcessingStep to GA4GH Program
+     *    converter, must not be null
+     */
+    RecordGroupToReadGroup(final Converter<ProcessingStep, Program> processingStepConverter) {
+        super(RecordGroup.class, ReadGroup.class);
+        checkNotNull(processingStepConverter);
+        this.processingStepConverter = processingStepConverter;
+    }
+
+
+    @Override
+    public ReadGroup convert(final RecordGroup recordGroup,
+                             final ConversionStringency stringency,
+                             final Logger logger) throws ConversionException {
+
+        if (recordGroup == null) {
+            warnOrThrow(recordGroup, "must not be null", null, stringency, logger);
+            return null;
+        }
+
+        ReadGroup.Builder builder = ReadGroup.newBuilder()
+            .setId(isNotEmpty(recordGroup.getName()) ? recordGroup.getName() : "1")
+            .setName(isNotEmpty(recordGroup.getName()) ? recordGroup.getName() : "1");
+
+        if (isNotEmpty(recordGroup.getSample())) {
+            builder.setSampleName(recordGroup.getSample());
+        }
+
+        if (isNotEmpty(recordGroup.getDescription())) {
+            builder.setDescription(recordGroup.getDescription());
+        }
+
+        if (recordGroup.getPredictedMedianInsertSize() != null) {
+            builder.setPredictedInsertSize(recordGroup.getPredictedMedianInsertSize());
+        }
+
+        if (!recordGroup.getProcessingSteps().isEmpty()) {
+            for (ProcessingStep processingStep : recordGroup.getProcessingSteps()) {
+                builder.addPrograms(processingStepConverter.convert(processingStep, stringency, logger));
+            }
+
+        }
+        return builder.build();
+    }
+}

--- a/convert-ga4gh/src/test/java/org/bdgenomics/convert/ga4gh/Ga4ghModuleTest.java
+++ b/convert-ga4gh/src/test/java/org/bdgenomics/convert/ga4gh/Ga4ghModuleTest.java
@@ -26,9 +26,12 @@ import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Guice;
 
+import ga4gh.Common.Program;
+
 import ga4gh.Reads.CigarUnit;
 import ga4gh.Reads.CigarUnit.Operation;
 import ga4gh.Reads.ReadAlignment;
+import ga4gh.Reads.ReadGroup;
 
 import htsjdk.samtools.Cigar;
 import htsjdk.samtools.CigarOperator;
@@ -38,6 +41,8 @@ import org.bdgenomics.convert.Converter;
 import org.bdgenomics.convert.bdgenomics.BdgenomicsModule;
 
 import org.bdgenomics.formats.avro.AlignmentRecord;
+import org.bdgenomics.formats.avro.ProcessingStep;
+import org.bdgenomics.formats.avro.RecordGroup;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -71,6 +76,10 @@ public final class Ga4ghModuleTest {
         assertNotNull(target.getCigarOperatorToOperation());
         assertNotNull(target.getCigarToCigarUnits());
         assertNotNull(target.getAlignmentRecordToReadAlignment());
+        assertNotNull(target.getProcessingStepToProgram());
+        assertNotNull(target.getProgramToProcessingStep());
+        assertNotNull(target.getReadGroupToRecordGroup());
+        assertNotNull(target.getRecordGroupToReadGroup());
     }
 
     /**
@@ -86,6 +95,10 @@ public final class Ga4ghModuleTest {
         Converter<CigarOperator, Operation> cigarOperatorToOperation;
         Converter<Cigar, List<CigarUnit>> cigarToCigarUnits;
         Converter<AlignmentRecord, ReadAlignment> alignmentRecordToReadAlignment;
+        Converter<ProcessingStep, Program> processingStepToProgram;
+        Converter<Program, ProcessingStep> programToProcessingStep;
+        Converter<ReadGroup, RecordGroup> readGroupToRecordGroup;
+        Converter<RecordGroup, ReadGroup> recordGroupToReadGroup;
 
         @Inject
         Target(final Converter<org.bdgenomics.formats.avro.Feature, ga4gh.SequenceAnnotations.Feature> bdgenomicsFeatureToGa4ghFeature,
@@ -96,7 +109,11 @@ public final class Ga4ghModuleTest {
                final Converter<ga4gh.Common.Strand, org.bdgenomics.formats.avro.Strand> ga4ghStrandToBdgenomicsStrand,
                final Converter<CigarOperator, Operation> cigarOperatorToOperation,
                final Converter<Cigar, List<CigarUnit>> cigarToCigarUnits,
-               final Converter<AlignmentRecord, ReadAlignment> alignmentRecordToReadAlignment) {
+               final Converter<AlignmentRecord, ReadAlignment> alignmentRecordToReadAlignment,
+               final Converter<ProcessingStep, Program> processingStepToProgram,
+               final Converter<Program, ProcessingStep> programToProcessingStep,
+               final Converter<ReadGroup, RecordGroup> readGroupToRecordGroup,
+               final Converter<RecordGroup, ReadGroup> recordGroupToReadGroup) {
 
             this.bdgenomicsFeatureToGa4ghFeature = bdgenomicsFeatureToGa4ghFeature;
             this.bdgenomicsOntologyTermToGa4ghOntologyTerm = bdgenomicsOntologyTermToGa4ghOntologyTerm;
@@ -107,6 +124,10 @@ public final class Ga4ghModuleTest {
             this.cigarOperatorToOperation = cigarOperatorToOperation;
             this.cigarToCigarUnits = cigarToCigarUnits;
             this.alignmentRecordToReadAlignment = alignmentRecordToReadAlignment;
+            this.processingStepToProgram = processingStepToProgram;
+            this.programToProcessingStep = programToProcessingStep;
+            this.readGroupToRecordGroup = readGroupToRecordGroup;
+            this.recordGroupToReadGroup = recordGroupToReadGroup;
         }
 
         Converter<org.bdgenomics.formats.avro.Feature, ga4gh.SequenceAnnotations.Feature> getBdgenomicsFeatureToGa4ghFeature() {
@@ -145,6 +166,21 @@ public final class Ga4ghModuleTest {
             return alignmentRecordToReadAlignment;
         }
 
+        Converter<ProcessingStep, Program> getProcessingStepToProgram() {
+            return processingStepToProgram;
+        }
+
+        Converter<Program, ProcessingStep> getProgramToProcessingStep() {
+            return programToProcessingStep;
+        }
+
+        Converter<ReadGroup, RecordGroup> getReadGroupToRecordGroup() {
+            return readGroupToRecordGroup;
+        }
+
+        Converter<RecordGroup, ReadGroup> getRecordGroupToReadGroup() {
+            return recordGroupToReadGroup;
+        }
     }
 
     /**

--- a/convert-ga4gh/src/test/java/org/bdgenomics/convert/ga4gh/ProcessingStepToProgramTest.java
+++ b/convert-ga4gh/src/test/java/org/bdgenomics/convert/ga4gh/ProcessingStepToProgramTest.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.convert.ga4gh;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+
+import ga4gh.Common.Program;
+
+import org.bdgenomics.convert.Converter;
+import org.bdgenomics.convert.ConversionException;
+import org.bdgenomics.convert.ConversionStringency;
+
+import org.bdgenomics.formats.avro.ProcessingStep;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Unit test for ProcessingStepToProgram.
+ */
+public final class ProcessingStepToProgramTest {
+    private final Logger logger = LoggerFactory.getLogger(ProcessingStepToProgramTest.class);
+    private Converter<ProcessingStep, Program> processingStepConverter;
+
+    @Before
+    public void setUp() {
+        processingStepConverter = new ProcessingStepToProgram();
+    }
+
+    @Test
+    public void testConstructor() {
+        assertNotNull(processingStepConverter);
+    }
+
+    @Test(expected=ConversionException.class)
+    public void testConvertNullStrict() {
+        processingStepConverter.convert(null, ConversionStringency.STRICT, logger);
+    }
+
+    @Test
+    public void testConvertNullLenient() {
+        assertNull(processingStepConverter.convert(null, ConversionStringency.LENIENT, logger));
+    }
+
+    @Test
+    public void testConvertNullSilent() {
+        assertNull(processingStepConverter.convert(null, ConversionStringency.SILENT, logger));
+    }
+
+    @Test
+    public void testConvert() {
+        ProcessingStep processingStep = ProcessingStep.newBuilder()
+            .setId("id")
+            .setProgramName("name")
+            .setCommandLine("command line")
+            .setPreviousId("previous id")
+            .setVersion("version")
+            .build();
+
+        Program program = processingStepConverter.convert(processingStep, ConversionStringency.STRICT, logger);
+        assertNotNull(program);
+        assertEquals(program.getId(), processingStep.getId());
+        assertEquals(program.getName(), processingStep.getProgramName());
+        assertEquals(program.getCommandLine(), processingStep.getCommandLine());
+        assertEquals(program.getPrevProgramId(), processingStep.getPreviousId());
+        assertEquals(program.getVersion(), processingStep.getVersion());
+    }
+}

--- a/convert-ga4gh/src/test/java/org/bdgenomics/convert/ga4gh/ProgramToProcessingStepTest.java
+++ b/convert-ga4gh/src/test/java/org/bdgenomics/convert/ga4gh/ProgramToProcessingStepTest.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.convert.ga4gh;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+
+import ga4gh.Common.Program;
+
+import org.bdgenomics.convert.Converter;
+import org.bdgenomics.convert.ConversionException;
+import org.bdgenomics.convert.ConversionStringency;
+
+import org.bdgenomics.formats.avro.ProcessingStep;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Unit test for ProgramToProcessingStep.
+ */
+public final class ProgramToProcessingStepTest {
+    private final Logger logger = LoggerFactory.getLogger(ProgramToProcessingStepTest.class);
+    private Converter<Program, ProcessingStep> programConverter;
+
+    @Before
+    public void setUp() {
+        programConverter = new ProgramToProcessingStep();
+    }
+
+    @Test
+    public void testConstructor() {
+        assertNotNull(programConverter);
+    }
+
+    @Test(expected=ConversionException.class)
+    public void testConvertNullStrict() {
+        programConverter.convert(null, ConversionStringency.STRICT, logger);
+    }
+
+    @Test
+    public void testConvertNullLenient() {
+        assertNull(programConverter.convert(null, ConversionStringency.LENIENT, logger));
+    }
+
+    @Test
+    public void testConvertNullSilent() {
+        assertNull(programConverter.convert(null, ConversionStringency.SILENT, logger));
+    }
+
+    @Test
+    public void testConvert() {
+        Program program = Program.newBuilder()
+            .setId("id")
+            .setName("name")
+            .setCommandLine("command line")
+            .setPrevProgramId("previous id")
+            .setVersion("version")
+            .build();
+
+        ProcessingStep processingStep = programConverter.convert(program, ConversionStringency.STRICT, logger);
+        assertNotNull(processingStep);
+        assertEquals(processingStep.getId(), program.getId());
+        assertEquals(processingStep.getProgramName(), program.getName());
+        assertEquals(processingStep.getCommandLine(), program.getCommandLine());
+        assertEquals(processingStep.getPreviousId(), program.getPrevProgramId());
+        assertEquals(processingStep.getVersion(), program.getVersion());
+    }
+}

--- a/convert-ga4gh/src/test/java/org/bdgenomics/convert/ga4gh/ReadGroupToRecordGroupTest.java
+++ b/convert-ga4gh/src/test/java/org/bdgenomics/convert/ga4gh/ReadGroupToRecordGroupTest.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.convert.ga4gh;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+
+import ga4gh.Common.Program;
+
+import ga4gh.Reads.ReadGroup;
+
+import org.bdgenomics.convert.Converter;
+import org.bdgenomics.convert.ConversionException;
+import org.bdgenomics.convert.ConversionStringency;
+
+import org.bdgenomics.formats.avro.ProcessingStep;
+import org.bdgenomics.formats.avro.RecordGroup;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Unit test for ReadGroupToRecordGroup.
+ */
+public final class ReadGroupToRecordGroupTest {
+    private final Logger logger = LoggerFactory.getLogger(ReadGroupToRecordGroupTest.class);
+    private Converter<Program, ProcessingStep> programConverter;
+    private Converter<ReadGroup, RecordGroup> readGroupConverter;
+
+    @Before
+    public void setUp() {
+        programConverter = new ProgramToProcessingStep();
+        readGroupConverter = new ReadGroupToRecordGroup(programConverter);
+    }
+
+    @Test
+    public void testConstructor() {
+        assertNotNull(readGroupConverter);
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void testConstructorNullProgramConverter() {
+        new ReadGroupToRecordGroup(null);
+    }
+
+    @Test(expected=ConversionException.class)
+    public void testConvertNullStrict() {
+        readGroupConverter.convert(null, ConversionStringency.STRICT, logger);
+    }
+
+    @Test
+    public void testConvertNullLenient() {
+        assertNull(readGroupConverter.convert(null, ConversionStringency.LENIENT, logger));
+    }
+
+    @Test
+    public void testConvertNullSilent() {
+        assertNull(readGroupConverter.convert(null, ConversionStringency.SILENT, logger));
+    }
+
+    @Test
+    public void testConvert() {
+        Program program = Program.newBuilder()
+            .setId("id")
+            .setName("name")
+            .setCommandLine("command line")
+            .setPrevProgramId("previous id")
+            .setVersion("version")
+            .build();
+
+        ReadGroup readGroup = ReadGroup.newBuilder()
+            .setName("readGroupName")
+            .setSampleName("readGroupSample")
+            .setDescription("readGroupDescription")
+            .setPredictedInsertSize(42)
+            .addPrograms(program)
+            .build();
+
+        RecordGroup recordGroup = readGroupConverter.convert(readGroup, ConversionStringency.STRICT, logger);
+        assertNotNull(recordGroup);
+        assertEquals(recordGroup.getName(), readGroup.getName());
+        assertEquals(recordGroup.getSample(), readGroup.getSampleName());
+        assertEquals(recordGroup.getDescription(), readGroup.getDescription());
+        assertEquals(recordGroup.getPredictedMedianInsertSize().intValue(), readGroup.getPredictedInsertSize());
+        assertFalse(recordGroup.getProcessingSteps().isEmpty());
+
+        ProcessingStep processingStep = recordGroup.getProcessingSteps().get(0);
+        assertNotNull(processingStep);
+        assertEquals(processingStep.getId(), program.getId());
+        assertEquals(processingStep.getProgramName(), program.getName());
+        assertEquals(processingStep.getCommandLine(), program.getCommandLine());
+        assertEquals(processingStep.getPreviousId(), program.getPrevProgramId());
+        assertEquals(processingStep.getVersion(), program.getVersion());
+    }
+}

--- a/convert-ga4gh/src/test/java/org/bdgenomics/convert/ga4gh/RecordGroupToReadGroupTest.java
+++ b/convert-ga4gh/src/test/java/org/bdgenomics/convert/ga4gh/RecordGroupToReadGroupTest.java
@@ -1,0 +1,123 @@
+/**
+ * Licensed to Big Data Genomics (BDG) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The BDG licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bdgenomics.convert.ga4gh;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ga4gh.Common.Program;
+
+import ga4gh.Reads.ReadGroup;
+
+import org.bdgenomics.convert.Converter;
+import org.bdgenomics.convert.ConversionException;
+import org.bdgenomics.convert.ConversionStringency;
+
+import org.bdgenomics.formats.avro.ProcessingStep;
+import org.bdgenomics.formats.avro.RecordGroup;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Unit test for RecordGroupToReadGroup.
+ */
+public final class RecordGroupToReadGroupTest {
+    private final Logger logger = LoggerFactory.getLogger(RecordGroupToReadGroup.class);
+    private Converter<ProcessingStep, Program> processingStepConverter;
+    private Converter<RecordGroup, ReadGroup> recordGroupConverter;
+
+    @Before
+    public void setUp() {
+        processingStepConverter = new ProcessingStepToProgram();
+        recordGroupConverter = new RecordGroupToReadGroup(processingStepConverter);
+    }
+
+    @Test
+    public void testConstructor() {
+        assertNotNull(recordGroupConverter);
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void testConstructorNullProcessingStepConverter() {
+        new RecordGroupToReadGroup(null);
+    }
+
+    @Test(expected=ConversionException.class)
+    public void testConvertNullStrict() {
+        recordGroupConverter.convert(null, ConversionStringency.STRICT, logger);
+    }
+
+    @Test
+    public void testConvertNullLenient() {
+        assertNull(recordGroupConverter.convert(null, ConversionStringency.LENIENT, logger));
+    }
+
+    @Test
+    public void testConvertNullSilent() {
+        assertNull(recordGroupConverter.convert(null, ConversionStringency.SILENT, logger));
+    }
+
+    @Test
+    public void testConvert() {
+        ProcessingStep processingStep = ProcessingStep.newBuilder()
+            .setId("id")
+            .setProgramName("name")
+            .setCommandLine("command line")
+            .setPreviousId("previous id")
+            .setVersion("version")
+            .build();
+
+        List<ProcessingStep> processingSteps = new ArrayList<ProcessingStep>(1);
+        processingSteps.add(processingStep);
+
+        RecordGroup recordGroup = RecordGroup.newBuilder()
+            .setName("recordGroupName")
+            .setSample("recordGroupSample")
+            .setDescription("recordGroupDescription")
+            .setPredictedMedianInsertSize(42)
+            .setProcessingSteps(processingSteps)
+            .build();
+
+        ReadGroup readGroup = recordGroupConverter.convert(recordGroup, ConversionStringency.STRICT, logger);
+        assertNotNull(readGroup);
+        assertEquals(readGroup.getId(), recordGroup.getName());
+        assertEquals(readGroup.getName(), recordGroup.getName());
+        assertEquals(readGroup.getSampleName(), recordGroup.getSample());
+        assertEquals(readGroup.getDescription(), recordGroup.getDescription());
+        assertEquals(readGroup.getPredictedInsertSize(), recordGroup.getPredictedMedianInsertSize().intValue());
+        assertFalse(readGroup.getProgramsList().isEmpty());
+        assertEquals(readGroup.getProgramsCount(), 1);
+
+        Program program = readGroup.getProgramsList().get(0);
+        assertNotNull(program);
+        assertEquals(program.getId(), processingStep.getId());
+        assertEquals(program.getName(), processingStep.getProgramName());
+        assertEquals(program.getCommandLine(), processingStep.getCommandLine());
+        assertEquals(program.getPrevProgramId(), processingStep.getPreviousId());
+        assertEquals(program.getVersion(), processingStep.getVersion());
+    }
+}


### PR DESCRIPTION
Fixes #53.

Downstream you'll need to convert `AlignmentRecordRDD.recordGroups` metadata explicitly, since the GA4GH-generated objects have no reference between `ReadAlignment`s and `ReadGroup`s, only a foreign-key relationship via `readGroupId`.